### PR TITLE
Fix csv convert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,4 @@ scripts/__pycache__/Stylez.cpython-310.pyc
 scripts/__pycache__/promptgen.cpython-310.pyc
 distilgpt2-stable-diffusion-v2/
 scripts/config.json
-scripts/config.json
-scripts/config.json
-scripts/config.json
-scripts/config.json
-scripts/config.json
+styles/CSVConversion


### PR DESCRIPTION
issue
if the user uses all non-English characters in their Styles name
style.csv conversion will fail
> example a Chinese user might use exclusively Chinese characters in their style name, if they do so because of the remove_special_characters they will have a blank name which is invalid

> PIL image can't save image with no name (`<blank>.jpg`), the extension will fail to load completely.

---

this PR changes so that it replace the illegal characters with full-width variant, as opposed to removing the character
demo / sorce of the replacement can be found at https://gist.github.com/w-e-w/f6c606faac8c2cebee49bdeb7226826c

hear I add an additional logic of if the input name is blank or the leading character is a `.`, a prefix `_` will be added
as it is also possible that someone have a style that has a `blank` name (not `None` or missing `blank`),
and because files with names starting with a `.` is blocked for beeing served by gradio

> if you don't like to replace it with full-width variant, you can replace it with some other characters like `_`

demo of a worst case situation
if some insane person uses illegal characters in the style name
.\t\n\v\f\ra*b/c:d<e>f?g\\h|i\t\n\v\f\r`
![image](https://github.com/javsezlol1/Stylez/assets/40751091/57d4673d-c188-4dff-bf73-d9e6afdd9746)

Note: I'm using a Windows system, even though I believe that my replacement logic should be compatible with Linux I'm not 100% certain

---

additional change
no reason to use PIL image save or copying in an image, change to use `shutil.copy`
enclose creation of entries in try block to ensure the extension executes even if something bad happened
remove duplicate .gitignore and add styles/CSVConversion to .gitignore 